### PR TITLE
Allowing inner Exception to be null in AerospikeException constructor

### DIFF
--- a/AerospikeClient/Main/AerospikeException.cs
+++ b/AerospikeClient/Main/AerospikeException.cs
@@ -36,7 +36,7 @@ namespace Aerospike.Client
 		}
 
 		public AerospikeException(int resultCode, Exception e)
-			: base(e.Message, e)
+			: base(e?.Message ?? string.Empty, e)
 		{
 			this.resultCode = resultCode;
 		}


### PR DESCRIPTION
Several AerospikeException.Timeout constructors take an optional null inner exception and use this constructor.

Right now, using these AerospikeException.Timeout constructors will result in an `Object reference not set to an instance of an object` error if no inner exception is given.